### PR TITLE
Fix/better exception handling

### DIFF
--- a/configure-tenant.ps1
+++ b/configure-tenant.ps1
@@ -1,14 +1,3 @@
-# Param(
-#     [Parameter(Mandatory=$true)]
-#     [string]$orgId,
-
-#     [Parameter(Mandatory=$true)]
-#     [string]$apiKey = ""
-
-#     [Parameter(Mandatory=$true)]
-#     [string]$gatewayname = ""
-# )
-
 #region # Connection #
 
 $ErrorActionPreference = "Stop"
@@ -504,6 +493,7 @@ foreach ($policyModel in $policiesModel) {
     else {
         # create policy
         Write-Host "  Creating policy: $($policyModel.description)"
+        #Write-Host $($policyModel | ConvertTo-Json -Depth 10)
         $null = Invoke-EnclaveApi -Method Post -Uri "https://api.enclave.io/org/$orgId/policies" -Body $policyModel
     }
 }

--- a/configure-tenant.ps1
+++ b/configure-tenant.ps1
@@ -3,7 +3,7 @@
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
-$env = "c:\repos\enclave\.env"
+$env = "$PWD\.env"
 $apikey = get-content $env | Where-Object { $_ -match 'ENCLAVE_APIKEY' } | ForEach-Object { $_.split('=')[1] }
 $orgid = get-content $env | Where-Object { $_ -match 'ENCLAVE_ORGID' } | ForEach-Object { $_.split('=')[1] }
 # write-output "$apikey"


### PR DESCRIPTION
With better error handling, we can see the API call is failing because, `"senderTags cannot contain duplicate values"`, and the script is posting 

```
"senderTags":  [
     "internet-gateway-admin",
     "internet-gateway",
     "internet-gateway-admin"
],
```

That's happening because of these lines

```
# assign ender tags to policies
$policiesModel[0].senderTags += $tags[1].name, $tags[3].name
$policiesModel[3].senderTags += $tags[1].name
```

Which I think we can take out in this version of the script. If you can confirm we don't need those lines @marjen-dev I'll update this PR to also remove those two lines.